### PR TITLE
fixed network picking

### DIFF
--- a/components/main/main.component.tsx
+++ b/components/main/main.component.tsx
@@ -17,22 +17,60 @@ export const MainComponent: React.FC<MainComponentProps> = ({
 }) => {
   const [openDropdown, setOpenDropdown] = useState<'from' | 'to' | null>(null)
 
-  const [fromNetwork, setFromNetwork] = useState({
+  const [fromNetwork, setFromNetwork] = useState<Network>({
     name: 'Tari',
     icon: '/icons/tari.png',
   })
 
-  const [toNetwork, setToNetwork] = useState({
+  const [toNetwork, setToNetwork] = useState<Network>({
     name: 'Ethereum',
     icon: '/icons/eth.png',
   })
 
   const { isConnected } = useAccount()
 
+  const fromNetworks = networks.filter(
+    (n) => n.name === 'Ethereum' || n.name === 'Tari',
+  )
+
   const handleNetworkSelect = (network: Network, type: 'from' | 'to') => {
-    if (type === 'from') setFromNetwork(network)
-    else setToNetwork(network)
+    if (type === 'from') {
+      // If selecting same network that's already in "To", swap them
+      if (network.name === toNetwork.name) {
+        const otherNetwork = fromNetworks.find((n) => n.name !== network.name)
+
+        if (otherNetwork) {
+          setFromNetwork(network)
+          setToNetwork(otherNetwork)
+        }
+      } else {
+        setFromNetwork(network)
+      }
+    } else {
+      // If selecting same network that's already in "From", swap them
+      if (network.name === fromNetwork.name) {
+        const otherNetwork = fromNetworks.find((n) => n.name !== network.name)
+
+        if (otherNetwork) {
+          setToNetwork(network)
+          setFromNetwork(otherNetwork)
+        }
+      } else {
+        setToNetwork(network)
+      }
+    }
     setOpenDropdown(null)
+  }
+
+  /** @dev TODO fetch balances dynamically */
+  const getAmount = () => {
+    return fromNetwork.name === 'Tari'
+      ? (1023451.931).toLocaleString()
+      : (328.22).toLocaleString()
+  }
+
+  const getAmountTokenSymbol = () => {
+    return fromNetwork.name === 'Tari' ? 'XTM' : 'wXTM'
   }
 
   return (
@@ -67,15 +105,13 @@ export const MainComponent: React.FC<MainComponentProps> = ({
               <div className="relative">
                 <div className="flex items-center">
                   <div className="relative flex gap-[2px] w-full items-stretch">
-                    {/* Box 1 */}
+                    {/* Box 1 - From */}
                     <div className="flex-1">
                       <NetworkBox
                         type="from"
                         selected={fromNetwork}
                         isOpen={openDropdown === 'from'}
-                        networks={networks.filter(
-                          (n) => n.name === 'Ethereum' || n.name === 'Tari',
-                        )}
+                        networks={fromNetworks}
                         onToggle={() =>
                           setOpenDropdown(
                             openDropdown === 'from' ? null : 'from',
@@ -87,7 +123,7 @@ export const MainComponent: React.FC<MainComponentProps> = ({
                       />
                     </div>
 
-                    {/* Box 2 */}
+                    {/* Box 2 - To */}
                     <div className="flex-1">
                       <NetworkBox
                         type="to"
@@ -100,10 +136,11 @@ export const MainComponent: React.FC<MainComponentProps> = ({
                         onSelect={(network) =>
                           handleNetworkSelect(network, 'to')
                         }
+                        fromNetwork={fromNetwork}
                       />
                     </div>
 
-                    {/* Box 3 */}
+                    {/* Box 3 - Amount */}
                     <div className="flex-1">
                       <div className="flex justify-between gap-2 items-center p-2 px-4 rounded-xl bg-white border border-gray-200">
                         <div className="space-y-[-10px]">
@@ -120,18 +157,20 @@ export const MainComponent: React.FC<MainComponentProps> = ({
                           <div className="w-fit flex py-2 px-3 bg-gray-200 items-center rounded-3xl justify-center self-end">
                             <div className="w-5 h-5 rounded-full overflow-hidden -ml-1 mr-2 relative">
                               <Image
-                                src="/icons/tari.png"
+                                src={fromNetwork.icon}
                                 fill
                                 sizes="20px"
-                                alt="Tari icon"
+                                alt={`${fromNetwork.name} icon`}
                                 className="rounded-full object-cover"
                               />
                             </div>
-                            <div className="font-bold text-[12.85px]">XTM</div>
+                            <div className="font-bold text-[12.85px]">
+                              {getAmountTokenSymbol()}
+                            </div>
                           </div>
                           <div className="flex justify-end mt-2 gap-1 items-center">
                             <div className="font-semibold text-xs text-gray-500">
-                              {(1023451.931).toLocaleString()} XTM
+                              {getAmount()} {getAmountTokenSymbol()}
                             </div>
                             <div className="border border-gray-500/50 rounded-3xl text-xs font-medium px-1.5">
                               MAX

--- a/components/network-box/network-box.tsx
+++ b/components/network-box/network-box.tsx
@@ -12,8 +12,28 @@ export const NetworkBox: React.FC<NetworkBoxProps> = ({
   onToggle,
   onSelect,
 }) => {
-  /** @dev Development */
-  const arrowsDisabled = true
+  const getTokenSymbol = () => {
+    if (type === 'from') {
+      return selected.name === 'Tari' ? 'XTM' : 'wXTM'
+    } else {
+      if (selected.name === 'Tari') return 'XTM'
+      if (selected.name === 'Solana') return 'SOL'
+      return 'wXTM'
+    }
+  }
+
+  const getFilteredNetworks = () => {
+    if (type === 'from') {
+      // For "From" box, only show networks that aren't currently selected
+      return networks.filter((network) => network.name !== selected.name)
+    } else {
+      // For "To" box, show all networks
+      return networks
+    }
+  }
+
+  const tokenSymbol = getTokenSymbol()
+  const filteredNetworks = getFilteredNetworks()
 
   return (
     <div className="relative">
@@ -30,25 +50,23 @@ export const NetworkBox: React.FC<NetworkBoxProps> = ({
         <div className="flex flex-col text-xs text-gray-500 font-medium">
           <div>{type === 'from' ? 'From' : 'To'}</div>
           <div className="text-xl font-bold text-[#171717] -my-1">
-            {type === 'from' ? 'XTM' : 'wXTM'}
+            {tokenSymbol}
           </div>
           <div>{selected.name}</div>
         </div>
 
-        {arrowsDisabled ? null : (
-          <div className="ml-auto cursor-pointer mr-2" onClick={onToggle}>
-            {isOpen ? (
-              <IoIosArrowUp className="text-xl" />
-            ) : (
-              <IoIosArrowDown className="text-xl" />
-            )}
-          </div>
-        )}
+        <div className="ml-auto cursor-pointer mr-2" onClick={onToggle}>
+          {isOpen ? (
+            <IoIosArrowUp className="text-xl" />
+          ) : (
+            <IoIosArrowDown className="text-xl" />
+          )}
+        </div>
       </div>
 
       {isOpen && (
         <div className="absolute bottom-full left-0 mt-2 w-full z-50 bg-white rounded-xl shadow-lg p-3 space-y-2">
-          {networks.map((network) => (
+          {filteredNetworks.map((network) => (
             <div
               key={network.name}
               className="flex items-center gap-2 p-2 rounded-md hover:bg-gray-100 cursor-pointer"
@@ -73,5 +91,3 @@ export const NetworkBox: React.FC<NetworkBoxProps> = ({
     </div>
   )
 }
-
-export default NetworkBox

--- a/components/network-box/network-box.types.ts
+++ b/components/network-box/network-box.types.ts
@@ -10,4 +10,5 @@ export type NetworkBoxProps = {
   networks: Network[]
   onToggle: () => void
   onSelect: (network: Network) => void
+  fromNetwork?: Network
 }


### PR DESCRIPTION
main panel now avoids same network on both sides of transaction, switching tx side now updated all networks and data (balance) accordingly in all 3 boxes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic network swapping when selecting the same network in both dropdowns.
  - Amount and token symbol display now update automatically based on the selected network.

- **Improvements**
  - Network selection dropdowns now filter available options more intuitively.
  - Token symbols and icons are displayed dynamically for each network selection.

- **Bug Fixes**
  - Arrow toggle UI in network selection is now consistently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->