### PR TITLE
fix: static build

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -17,7 +17,8 @@ export const Providers = ({ children }: { children: ReactNode }) => {
     setInitialState(state)
   }, [config])
 
-  if (!initialState) return null
+  if (!initialState)
+    console.error('[ Bridge ] provider initial state undefined')
 
   return (
     <WagmiProvider config={config} initialState={initialState}>


### PR DESCRIPTION
Static build failed because it got null

![image](https://github.com/user-attachments/assets/7cbd95cc-2ad2-4200-8076-1100a4b68299)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when initial settings are missing by logging an error message instead of stopping the app from rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->