### PR TITLE
fix: jump straight to the wrapping modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,8 +29,9 @@ export default function Home() {
   })
 
   const { bridgeToEthereum, getBridgeTxParams } = useBridgeToEthereum()
-  const { tariAccount, isOngoingBridgeTx, ongoingBridgeTx } = useTariAccount()
+  const { tariAccount, isOngoingBridgeTx } = useTariAccount()
   const { getUserTransactions } = useBridgeTransaction()
+  const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
 
   const {
     watch,
@@ -79,8 +80,8 @@ export default function Home() {
     }
 
     fetchUserTransactions()
-    // Poll every 1 min
-    const intervalId = setInterval(fetchUserTransactions, 60000)
+    // Poll every 30 sec
+    const intervalId = setInterval(fetchUserTransactions, 30000)
 
     return () => {
       clearInterval(intervalId)
@@ -118,6 +119,7 @@ export default function Home() {
     bridgeToEthereum({
       amount,
       ethAddress: ethAddress,
+      amountAfterFee: feesData.amountAfterFee,
     })
       .then(() => {
         getUserTransactions()
@@ -125,7 +127,13 @@ export default function Home() {
       .catch((error) => {
         console.error('[ TAPPLET-BRIDGE ] Bridge operation failed:', error)
       })
-  }, [amount, ethAddress, bridgeToEthereum, getUserTransactions])
+  }, [
+    amount,
+    ethAddress,
+    bridgeToEthereum,
+    feesData.amountAfterFee,
+    getUserTransactions,
+  ])
 
   const handleBridgeToTari = () => {
     setModalStep(2)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,10 +30,11 @@ export default function Home() {
 
   const { bridgeToEthereum, getBridgeTxParams } = useBridgeToEthereum()
   const tariAccount = useTariAccount((s) => s.tariAccount)
-  const isOngoingBridgeTx = useTariAccount((s) => s.isOngoingBridgeTx)
+  // const isOngoingBridgeTx = useTariAccount((s) => s.isOngoingBridgeTx) //TODO NOT NEEDED - CAN BE REMOVED
 
   const { getUserTransactions } = useBridgeTransaction()
-  const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
+  // const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
+  const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
 
   const {
     watch,
@@ -72,7 +73,11 @@ export default function Home() {
 
     const fetchUserTransactions = async () => {
       try {
-        await getUserTransactions()
+        const txs = await getUserTransactions()
+        console.info(
+          '[ TAPPLET-BRIDGE ] successfully get user transactions:',
+          txs,
+        )
       } catch (error) {
         console.error(
           '[ TAPPLET-BRIDGE ] Failed to get user transactions:',
@@ -95,11 +100,11 @@ export default function Home() {
     if (modalOpen && modalStep === 0 && isConnected) {
       setModalOpen(false)
       setModalStep(1)
-    } else if (isOngoingBridgeTx && ongoingBridgeTx) {
+    } else if (ongoingBridgeTx) {
       setModalStep(2)
       setModalOpen(true)
     }
-  }, [isConnected, modalOpen, modalStep, isOngoingBridgeTx, ongoingBridgeTx])
+  }, [isConnected, modalOpen, modalStep, ongoingBridgeTx])
 
   const handleConnectClick = () => {
     if (!isConnected) {
@@ -155,7 +160,7 @@ export default function Home() {
         setFromNetwork={setFromNetwork}
         toNetwork={toNetwork}
         setToNetwork={setToNetwork}
-        isOngoingBridgeTx={isOngoingBridgeTx}
+        isOngoingBridgeTx={!!ongoingBridgeTx}
       />
       {modalOpen && (
         <MainModal
@@ -168,7 +173,7 @@ export default function Home() {
           setStep={setModalStep}
           handleBridgeToEthereum={handleBridgeToEthereum}
           handleBridgeToTari={handleBridgeToTari}
-          isBridging={isOngoingBridgeTx}
+          isBridging={!!ongoingBridgeTx}
           amount={amount}
           ethereumAddress={ethAddress}
           tariWalletAddress={tariAccount?.address}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,11 +29,8 @@ export default function Home() {
   })
 
   const { bridgeToEthereum, getBridgeTxParams } = useBridgeToEthereum()
-  const tariAccount = useTariAccount((s) => s.tariAccount)
-  // const isOngoingBridgeTx = useTariAccount((s) => s.isOngoingBridgeTx) //TODO NOT NEEDED - CAN BE REMOVED
-
   const { getUserTransactions } = useBridgeTransaction()
-  // const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
+  const tariAccount = useTariAccount((s) => s.tariAccount)
   const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
 
   const {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,11 +70,7 @@ export default function Home() {
 
     const fetchUserTransactions = async () => {
       try {
-        const txs = await getUserTransactions()
-        console.info(
-          '[ TAPPLET-BRIDGE ] successfully get user transactions:',
-          txs,
-        )
+        await getUserTransactions()
       } catch (error) {
         console.error(
           '[ TAPPLET-BRIDGE ] Failed to get user transactions:',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,9 @@ export default function Home() {
   })
 
   const { bridgeToEthereum, getBridgeTxParams } = useBridgeToEthereum()
-  const { tariAccount, isOngoingBridgeTx } = useTariAccount()
+  const tariAccount = useTariAccount((s) => s.tariAccount)
+  const isOngoingBridgeTx = useTariAccount((s) => s.isOngoingBridgeTx)
+
   const { getUserTransactions } = useBridgeTransaction()
   const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
 

--- a/clients/tari-l1-signer.ts
+++ b/clients/tari-l1-signer.ts
@@ -113,9 +113,9 @@ export class TariL1Signer {
    * @description add to TU store pending transaction
    * @returns true or false
    */
-  public async addPendingTappletTx(tx: BridgeTxDetails): Promise<boolean> {
+  public async setOngoingBridgeTx(tx: BridgeTxDetails): Promise<boolean> {
     return this.sendRequest({
-      methodName: 'addPendingTappletTx',
+      methodName: 'setOngoingBridgeTx',
       args: [tx],
     })
   }
@@ -124,9 +124,9 @@ export class TariL1Signer {
    * @description check if there is any pending transaction
    * @returns true or false
    */
-  public async getPendingTappletTx(): Promise<BridgeTxDetails | undefined> {
+  public async getOngoingBridgeTx(): Promise<BridgeTxDetails | undefined> {
     return this.sendRequest({
-      methodName: 'getPendingTappletTx',
+      methodName: 'getOngoingBridgeTx',
       args: [],
     })
   }
@@ -135,10 +135,10 @@ export class TariL1Signer {
    * @description check if there is any pending transaction
    * @returns true or false
    */
-  public async removePendingTappletTx(paymentId: string): Promise<boolean> {
+  public async removeOngoingBridgeTx(): Promise<boolean> {
     return this.sendRequest({
-      methodName: 'removePendingTappletTx',
-      args: [paymentId],
+      methodName: 'removeOngoingBridgeTx',
+      args: [],
     })
   }
 

--- a/components/bridge-input/bridge-input.tsx
+++ b/components/bridge-input/bridge-input.tsx
@@ -14,7 +14,7 @@ export const BridgeInput: React.FC<BridgeInputProps> = ({
 }) => {
   const [valueLength, setValueLength] = useState(5)
   const { fromToken } = useBridgeInfo(fromNetwork)
-  const { available_balance } = useTariAccount()
+  const available_balance = useTariAccount((s) => s.available_balance)
 
   // Helper to block invalid keys
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/components/main/main.component.tsx
+++ b/components/main/main.component.tsx
@@ -37,7 +37,7 @@ export const MainComponent: React.FC<MainComponentProps> = ({
 
   const { isConnected, chain, address } = useAccount()
   const { fromToken } = useBridgeInfo(fromNetwork)
-  const { available_balance } = useTariAccount()
+  const available_balance = useTariAccount((s) => s.available_balance)
 
   const chainId = (chain?.id ?? 1) as DeployedChains
   const deployments = getDeployments(chainId)

--- a/components/modals/failed-modal/failed-modal.tsx
+++ b/components/modals/failed-modal/failed-modal.tsx
@@ -4,17 +4,20 @@ import { FailedModalProps } from './failed-modal.types'
 import { ModalButton } from '@/components/modals/modal-button'
 
 import useTariAccount from '@/store/account'
+import useTariSigner from '@/store/signer'
 
 export const FailedModal: React.FC<FailedModalProps> = ({ closeModal }) => {
+  const signer = useTariSigner((s) => s.signer)
   const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
   const removeOngoingTransaction = useTariAccount(
     (s) => s.removeOngoingTransaction,
   )
 
-  const handleOnClick = useCallback(() => {
+  const handleOnClick = useCallback(async () => {
     closeModal()
     removeOngoingTransaction()
-  }, [closeModal, removeOngoingTransaction])
+    if (signer) await signer.removeOngoingBridgeTx()
+  }, [closeModal, removeOngoingTransaction, signer])
 
   return (
     <div className="w-full flex flex-col p-6">

--- a/components/modals/failed-modal/failed-modal.tsx
+++ b/components/modals/failed-modal/failed-modal.tsx
@@ -6,7 +6,10 @@ import { ModalButton } from '@/components/modals/modal-button'
 import useTariAccount from '@/store/account'
 
 export const FailedModal: React.FC<FailedModalProps> = ({ closeModal }) => {
-  const { removeOngoingTransaction, ongoingBridgeTx } = useTariAccount()
+  const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
+  const removeOngoingTransaction = useTariAccount(
+    (s) => s.removeOngoingTransaction,
+  )
 
   const handleOnClick = useCallback(() => {
     closeModal()

--- a/components/modals/success-modal/success-modal.tsx
+++ b/components/modals/success-modal/success-modal.tsx
@@ -6,6 +6,7 @@ import { ModalButton } from '@/components/modals/modal-button'
 import { useBridgeInfo } from '@/hooks/use-bridge-info'
 import useTariAccount from '@/store/account'
 import { formatUnits } from 'ethers'
+import useTariSigner from '@/store/signer'
 
 export const SuccessModal: React.FC<SuccessModalProps> = ({
   closeModal,
@@ -13,6 +14,7 @@ export const SuccessModal: React.FC<SuccessModalProps> = ({
   ethereumAddress,
   fromNetwork,
 }) => {
+  const signer = useTariSigner((s) => s.signer)
   const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
   const removeOngoingTransaction = useTariAccount(
     (s) => s.removeOngoingTransaction,
@@ -24,10 +26,11 @@ export const SuccessModal: React.FC<SuccessModalProps> = ({
     tariWalletAddress!,
   )
 
-  const handleOnClick = useCallback(() => {
+  const handleOnClick = useCallback(async () => {
     closeModal()
     removeOngoingTransaction()
-  }, [closeModal, removeOngoingTransaction])
+    if (signer) await signer.removeOngoingBridgeTx()
+  }, [closeModal, removeOngoingTransaction, signer])
 
   const amount = ongoingBridgeTx?.tokenAmount
     ? parseFloat(formatUnits(ongoingBridgeTx?.tokenAmount, 6)).toPrecision()

--- a/components/modals/success-modal/success-modal.tsx
+++ b/components/modals/success-modal/success-modal.tsx
@@ -13,7 +13,10 @@ export const SuccessModal: React.FC<SuccessModalProps> = ({
   ethereumAddress,
   fromNetwork,
 }) => {
-  const { removeOngoingTransaction, ongoingBridgeTx } = useTariAccount()
+  const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
+  const removeOngoingTransaction = useTariAccount(
+    (s) => s.removeOngoingTransaction,
+  )
 
   const { fromToken, toToken } = useBridgeInfo(
     fromNetwork,

--- a/components/modals/wrap-modal/wrap-modal.tsx
+++ b/components/modals/wrap-modal/wrap-modal.tsx
@@ -13,7 +13,7 @@ export const WrapModal: React.FC<WrapModalProps> = ({
   feesData,
 }) => {
   const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
-  const { fromToken, toToken, destAddress } = useBridgeInfo(
+  const bridgeInfo = useBridgeInfo(
     fromNetwork,
     ethereumAddress!,
     tariWalletAddress!,
@@ -22,9 +22,14 @@ export const WrapModal: React.FC<WrapModalProps> = ({
     ? parseFloat(formatUnits(ongoingBridgeTx.amountAfterFee, 6)).toPrecision()
     : feesData.amountAfterFee
 
-  const destAddressPending = ongoingBridgeTx?.destinationAddress ?? destAddress
+  const destAddressPending =
+    ongoingBridgeTx?.destinationAddress ?? bridgeInfo.destAddress
 
-  const { title, subtext } = getModalTitle(fromToken, feesData, ongoingBridgeTx)
+  const { title, subtext } = getModalTitle(
+    bridgeInfo,
+    feesData,
+    ongoingBridgeTx,
+  )
 
   return (
     <div className="w-full flex flex-col p-6">
@@ -51,7 +56,7 @@ export const WrapModal: React.FC<WrapModalProps> = ({
           <div className="font-medium">
             <div className="text-xs text-gray-500">Amount to receive</div>
             <div className="text-sm">
-              {amountAfterFeePending} {toToken}
+              {amountAfterFeePending} {bridgeInfo.toToken}
             </div>
           </div>
 

--- a/components/modals/wrap-modal/wrap-modal.tsx
+++ b/components/modals/wrap-modal/wrap-modal.tsx
@@ -12,7 +12,7 @@ export const WrapModal: React.FC<WrapModalProps> = ({
   fromNetwork,
   feesData,
 }) => {
-  const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
+  const ongoingBridgeTx = useTariAccount((s) => s.ongoingBridgeTx)
   const { fromToken, toToken, destAddress } = useBridgeInfo(
     fromNetwork,
     ethereumAddress!,

--- a/components/modals/wrap-modal/wrap-modal.tsx
+++ b/components/modals/wrap-modal/wrap-modal.tsx
@@ -3,8 +3,8 @@ import Image from 'next/image'
 import { WrapModalProps } from './wrap-modal.types'
 import { useBridgeInfo } from '@/hooks/use-bridge-info'
 import useTariAccount from '@/store/account'
-import { formatUnits } from 'ethers'
 import { getModalTitle } from '@/utils/transaction'
+import { formatUnits } from 'ethers'
 
 export const WrapModal: React.FC<WrapModalProps> = ({
   tariWalletAddress,
@@ -12,15 +12,14 @@ export const WrapModal: React.FC<WrapModalProps> = ({
   fromNetwork,
   feesData,
 }) => {
-  const { ongoingBridgeTx } = useTariAccount()
+  const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
   const { fromToken, toToken, destAddress } = useBridgeInfo(
     fromNetwork,
     ethereumAddress!,
     tariWalletAddress!,
   )
-
   const amountAfterFeePending = ongoingBridgeTx?.amountAfterFee
-    ? formatUnits(ongoingBridgeTx.amountAfterFee, 6)
+    ? parseFloat(formatUnits(ongoingBridgeTx.amountAfterFee, 6)).toPrecision()
     : feesData.amountAfterFee
 
   const destAddressPending = ongoingBridgeTx?.destinationAddress ?? destAddress
@@ -52,7 +51,7 @@ export const WrapModal: React.FC<WrapModalProps> = ({
           <div className="font-medium">
             <div className="text-xs text-gray-500">Amount to receive</div>
             <div className="text-sm">
-              {parseFloat(amountAfterFeePending).toPrecision()} {toToken}
+              {amountAfterFeePending} {toToken}
             </div>
           </div>
 

--- a/hooks/use-bridge-info.ts
+++ b/hooks/use-bridge-info.ts
@@ -1,24 +1,32 @@
 import { useMemo } from 'react'
 import { Network } from '@/components/network-box'
 
+export type BridgeInfo = {
+  fromToken: string
+  toToken: string
+  isWrapping: boolean
+  destAddress?: string
+  bridgeHandler?: () => void
+}
+
 export const useBridgeInfo = (
   fromNetwork: Network,
   ethereumAddress?: string,
   tariWalletAddress?: string,
   handleBridgeToEthereum?: () => void,
   handleBridgeToTari?: () => void,
-) => {
+): BridgeInfo => {
   return useMemo(() => {
-    const isFromTari = fromNetwork.name === 'Tari'
+    const isWrapping = fromNetwork.name === 'Tari'
 
-    const fromToken = isFromTari ? 'XTM' : 'wXTM'
-    const toToken = isFromTari ? 'wXTM' : 'XTM'
-    const destAddress = isFromTari ? ethereumAddress : tariWalletAddress
-    const bridgeHandler = isFromTari
+    const fromToken = isWrapping ? 'XTM' : 'wXTM'
+    const toToken = isWrapping ? 'wXTM' : 'XTM'
+    const destAddress = isWrapping ? ethereumAddress : tariWalletAddress
+    const bridgeHandler = isWrapping
       ? handleBridgeToEthereum
       : handleBridgeToTari
 
-    return { fromToken, toToken, destAddress, bridgeHandler }
+    return { fromToken, toToken, isWrapping, destAddress, bridgeHandler }
   }, [
     fromNetwork.name,
     ethereumAddress,

--- a/hooks/use-bridge-to-ethereum-fees/use-bridge-to-ethereum-fees.ts
+++ b/hooks/use-bridge-to-ethereum-fees/use-bridge-to-ethereum-fees.ts
@@ -8,7 +8,10 @@ import useTariAccount from '@/store/account'
 export const useBridgeToEthereumFees = (
   tokenAmount: string,
 ): BridgeToEthereumFees => {
-  const { wrapTokenFeePercentageBps } = useTariAccount()
+  const wrapTokenFeePercentageBps = useTariAccount(
+    (s) => s.wrapTokenFeePercentageBps,
+  )
+
   return useMemo(() => {
     try {
       if (!tokenAmount || tokenAmount.trim() === '') {

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -71,12 +71,12 @@ export const useBridgeToEthereum = () => {
 
     // TODO add this line to store ongoing tx also in the TU to check on tapplet reload
     // if any previous tx was finished with success/fail status to display it to a user
-    // await signer?.addPendingTappletTx({
-    //   amount: amount,
-    //   amountToReceive: amountAfterFee,
-    //   destinationAddress: ethAddress,
-    //   paymentId: paymentId,
-    // })
+    await signer?.setOngoingBridgeTx({
+      amount: amount,
+      amountToReceive: amountAfterFee,
+      destinationAddress: ethAddress,
+      paymentId: paymentId,
+    })
 
     if (!isSend) {
       console.error('[ TAPPLET-BRIDGE ] send one sided failed')

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -1,7 +1,10 @@
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
 
-import { WrapTokenService } from '@tari-project/wxtm-bridge-backend-api'
+import {
+  UserTransactionDTO,
+  WrapTokenService,
+} from '@tari-project/wxtm-bridge-backend-api'
 
 import { parseWxtmTokenAmount } from '@/utils/parse-wxtm-token-amount'
 import useTariSigner from '@/store/signer'
@@ -24,26 +27,33 @@ export const useBridgeToEthereum = () => {
     setWrapTokenFeePercentageBps,
     setTariColdWalletAddress,
     setIsOngoingBridgeTx,
+    setOngoingTransaction,
   } = useTariAccount()
   const [isBridging, setIsBridging] = useState(false)
 
   const bridgeToEthereum = async ({
     amount,
     ethAddress,
+    amountAfterFee,
   }: {
     amount: string
     ethAddress: `0x${string}`
+    amountAfterFee: string
   }) => {
     setIsBridging(true)
     setIsOngoingBridgeTx(true)
     if (!tariAccount || !signer) return
 
     const parsedAmount = parseWxtmTokenAmount(amount)
-
-    console.debug(
-      '[ TAPPLET-BRIDGE ] start bridging to eth with amount:',
-      parsedAmount,
-    )
+    // temporary solution to display wrapping modal
+    setOngoingTransaction({
+      destinationAddress: ethAddress,
+      tokenAmount: parsedAmount,
+      amountAfterFee: parseWxtmTokenAmount(amountAfterFee),
+      status: UserTransactionDTO.status.PENDING,
+      createdAt: '',
+      paymentId: '',
+    })
 
     const { paymentId } = await createTransaction.mutateAsync({
       to: ethAddress,
@@ -86,11 +96,6 @@ export const useBridgeToEthereum = () => {
 
       setTariColdWalletAddress(coldWalletAddress)
       setWrapTokenFeePercentageBps(wrapTokenFeePercentageBps)
-      console.warn(
-        '!!!!! [ TAPPLET-BRIDGE ][gettxparams] set bridge tx params',
-        coldWalletAddress,
-        wrapTokenFeePercentageBps,
-      )
     } catch (error) {
       console.error('[ TAPPLET-BRIDGE ] Failed to fetch token params:', error)
     }

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -69,7 +69,7 @@ export const useBridgeToEthereum = () => {
       paymentId: paymentId,
     })
 
-    // TODO add this line to store ongoing tx also in the TU to check on tapplet reload
+    // add this line to store ongoing tx also in the TU to check on tapplet reload
     // if any previous tx was finished with success/fail status to display it to a user
     await signer?.setOngoingBridgeTx({
       amount: amount,

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -74,6 +74,8 @@ export const useBridgeToEthereum = () => {
       paymentId: paymentId,
     })
 
+    // TODO add this line to store ongoing tx also in the TU to check on tapplet reload
+    // if any previous tx was finished with success/fail status to display it to a user
     // await signer?.addPendingTappletTx({
     //   amount: amount,
     //   amountToReceive: amountAfterFee,

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -20,16 +20,19 @@ export const useBridgeToEthereum = () => {
   const getWrapTokenParams = useMutation({
     mutationFn: WrapTokenService.getWrapTokenParams,
   })
-  const { signer } = useTariSigner()
-  const {
-    tariAccount,
-    tariColdWalletAddress,
-    setWrapTokenFeePercentageBps,
-    setTariColdWalletAddress,
-    setIsOngoingBridgeTx,
-    setOngoingTransaction,
-  } = useTariAccount()
-  const [isBridging, setIsBridging] = useState(false)
+
+  const [isBridging, setIsBridging] = useState(false) //TODO can be removed since the store is used
+  const signer = useTariSigner((s) => s.signer)
+  const tariAccount = useTariAccount((s) => s.tariAccount)
+  const tariColdWalletAddress = useTariAccount((s) => s.tariColdWalletAddress)
+  const setWrapTokenFeePercentageBps = useTariAccount(
+    (s) => s.setWrapTokenFeePercentageBps,
+  )
+  const setTariColdWalletAddress = useTariAccount(
+    (s) => s.setTariColdWalletAddress,
+  )
+  const setIsOngoingBridgeTx = useTariAccount((s) => s.setIsOngoingBridgeTx)
+  const setOngoingTransaction = useTariAccount((s) => s.setOngoingTransaction)
 
   const bridgeToEthereum = async ({
     amount,
@@ -45,20 +48,21 @@ export const useBridgeToEthereum = () => {
     if (!tariAccount || !signer) return
 
     const parsedAmount = parseWxtmTokenAmount(amount)
-    // temporary solution to display wrapping modal
+
+    const { paymentId } = await createTransaction.mutateAsync({
+      to: ethAddress,
+      from: tariAccount.address,
+      tokenAmount: parsedAmount,
+    })
+
+    // set ongoing to immediately display wrap modal
     setOngoingTransaction({
       destinationAddress: ethAddress,
       tokenAmount: parsedAmount,
       amountAfterFee: parseWxtmTokenAmount(amountAfterFee),
       status: UserTransactionDTO.status.PENDING,
       createdAt: '',
-      paymentId: '',
-    })
-
-    const { paymentId } = await createTransaction.mutateAsync({
-      to: ethAddress,
-      from: tariAccount.address,
-      tokenAmount: parsedAmount,
+      paymentId: paymentId,
     })
     console.debug('[ TAPPLET-BRIDGE ] created tx with id: ', paymentId)
 

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { useState } from 'react'
 
 import {
   UserTransactionDTO,
@@ -21,7 +20,6 @@ export const useBridgeToEthereum = () => {
     mutationFn: WrapTokenService.getWrapTokenParams,
   })
 
-  const [isBridging, setIsBridging] = useState(false) //TODO can be removed since the store is used
   const signer = useTariSigner((s) => s.signer)
   const tariAccount = useTariAccount((s) => s.tariAccount)
   const tariColdWalletAddress = useTariAccount((s) => s.tariColdWalletAddress)
@@ -31,7 +29,6 @@ export const useBridgeToEthereum = () => {
   const setTariColdWalletAddress = useTariAccount(
     (s) => s.setTariColdWalletAddress,
   )
-  const setIsOngoingBridgeTx = useTariAccount((s) => s.setIsOngoingBridgeTx)
   const setOngoingTransaction = useTariAccount((s) => s.setOngoingTransaction)
 
   const bridgeToEthereum = async ({
@@ -43,8 +40,6 @@ export const useBridgeToEthereum = () => {
     ethAddress: `0x${string}`
     amountAfterFee: string
   }) => {
-    setIsBridging(true)
-    setIsOngoingBridgeTx(true)
     if (!tariAccount || !signer) return
 
     const parsedAmount = parseWxtmTokenAmount(amount)
@@ -91,8 +86,6 @@ export const useBridgeToEthereum = () => {
     if (!success) {
       console.error('[ TAPPLET-BRIDGE ] confirm token sent failed')
     }
-
-    setIsBridging(false)
   }
 
   const getBridgeTxParams = async () => {
@@ -109,7 +102,6 @@ export const useBridgeToEthereum = () => {
 
   return {
     bridgeToEthereum,
-    isBridging,
     getBridgeTxParams,
   }
 }

--- a/hooks/use-bridge-transaction.ts
+++ b/hooks/use-bridge-transaction.ts
@@ -24,6 +24,8 @@ export const useBridgeTransaction = () => {
   const getUserTransactions =
     async (): Promise<PendingUserTransaction | null> => {
       const ongoingBridgeTx = useTariAccount.getState().ongoingBridgeTx
+      const lastOngoingPaymentIdFromTU =
+        useTariAccount.getState().lastOngoingPaymentIdFromTU
       const tariAccount = useTariAccount.getState().tariAccount
 
       if (!tariAccount) return null
@@ -44,11 +46,13 @@ export const useBridgeTransaction = () => {
         }
 
         // If no pending tx found, but previously had one, check if it succeeded/failed
+        // check also with the paymentId from the TU to display modal after the bridge restart
         const ongoingCompleted = transactions.find(
           (tx) =>
             (tx.status === UserTransactionDTO.status.SUCCESS ||
               tx.status === UserTransactionDTO.status.TIMEOUT) &&
-            tx.paymentId === ongoingBridgeTx?.paymentId,
+            (tx.paymentId === ongoingBridgeTx?.paymentId ||
+              lastOngoingPaymentIdFromTU === ongoingBridgeTx?.paymentId),
         )
 
         if (ongoingCompleted) {

--- a/hooks/use-bridge-transaction.ts
+++ b/hooks/use-bridge-transaction.ts
@@ -46,13 +46,19 @@ export const useBridgeTransaction = () => {
         }
 
         // If no pending tx found, but previously had one, check if it succeeded/failed
-        // check also with the paymentId from the TU to display modal after the bridge restart
+        // check also with the paymentId from the TU to display modal after the bridge relaunch
+        const validPaymentIds = new Set([
+          ongoingBridgeTx?.paymentId,
+          lastOngoingPaymentIdFromTU,
+        ])
+        const validStatuses = new Set([
+          UserTransactionDTO.status.SUCCESS,
+          UserTransactionDTO.status.TIMEOUT,
+        ])
+
         const ongoingCompleted = transactions.find(
-          (tx) =>
-            (tx.status === UserTransactionDTO.status.SUCCESS ||
-              tx.status === UserTransactionDTO.status.TIMEOUT) &&
-            (tx.paymentId === ongoingBridgeTx?.paymentId ||
-              lastOngoingPaymentIdFromTU === ongoingBridgeTx?.paymentId),
+          ({ paymentId, status }) =>
+            validPaymentIds.has(paymentId) && validStatuses.has(status),
         )
 
         if (ongoingCompleted) {

--- a/hooks/use-bridge-transaction.ts
+++ b/hooks/use-bridge-transaction.ts
@@ -13,7 +13,9 @@ export const useBridgeTransaction = () => {
     mutationFn: WrapTokenService.getUserTransactions,
   })
 
-  const { setOngoingTransaction, removeOngoingTransaction } = useTariAccount()
+  const setOngoingTransaction = useTariAccount.getState().setOngoingTransaction
+  const removeOngoingTransaction =
+    useTariAccount.getState().removeOngoingTransaction
 
   /**
    * Fetch user transactions and update the store's ongoing transaction state.

--- a/store/account.ts
+++ b/store/account.ts
@@ -6,7 +6,6 @@ import { OpenAPI } from '@tari-project/wxtm-bridge-backend-api'
 interface State {
   tariAccount?: AccountData
   available_balance: number
-  isOngoingBridgeTx: boolean
   ongoingBridgeTx?: PendingUserTransaction
   language: string
   walletconnect_id: string
@@ -22,7 +21,6 @@ interface Actions {
   removeOngoingTransaction: () => void
   setWrapTokenFeePercentageBps: (fee: number) => void
   setTariColdWalletAddress: (address: string) => void
-  setIsOngoingBridgeTx: (isOngoing: boolean) => void
 }
 
 type TariL1WalletStoreState = State & Actions
@@ -34,8 +32,6 @@ const initialState: State = {
   },
   available_balance: 0,
   ongoingBridgeTx: undefined,
-  // this can be replaced by check !!ongoingBridgeTx
-  isOngoingBridgeTx: false,
   // all below can be moved to separate store
   language: '',
   walletconnect_id: '',
@@ -85,13 +81,11 @@ export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
   setOngoingTransaction: (tx: PendingUserTransaction) => {
     set({
       ongoingBridgeTx: tx,
-      isOngoingBridgeTx: true,
     })
   },
   removeOngoingTransaction: () => {
     set({
       ongoingBridgeTx: undefined,
-      isOngoingBridgeTx: false,
     })
   },
   setWrapTokenFeePercentageBps: (fee: number) => {
@@ -102,11 +96,6 @@ export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
   setTariColdWalletAddress: (address: string) => {
     set({
       tariColdWalletAddress: address,
-    })
-  },
-  setIsOngoingBridgeTx: (isOngoing: boolean) => {
-    set({
-      isOngoingBridgeTx: isOngoing,
     })
   },
 }))

--- a/store/account.ts
+++ b/store/account.ts
@@ -13,6 +13,7 @@ interface State {
   bridge_api: string
   wrapTokenFeePercentageBps: number
   tariColdWalletAddress: string
+  lastOngoingPaymentIdFromTU: string
 }
 
 interface Actions {
@@ -41,6 +42,7 @@ const initialState: State = {
   bridge_api: '',
   wrapTokenFeePercentageBps: 50, // 0.5% fee
   tariColdWalletAddress: '',
+  lastOngoingPaymentIdFromTU: '',
 }
 
 export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
@@ -57,6 +59,7 @@ export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
       const balance = await signer.getTariBalance()
       const language = await signer.getAppLanguage()
       const envs = await signer.getBridgeEnvs()
+      const ongoingBridgeTx = await signer.getOngoingBridgeTx()
       const id = envs?.[0] ?? ''
       set({
         tariAccount: {
@@ -67,6 +70,7 @@ export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
         language: language,
         walletconnect_id: envs?.[0] ?? '',
         bridge_api: envs?.[1] ?? '',
+        lastOngoingPaymentIdFromTU: ongoingBridgeTx?.paymentId ?? '',
       })
       OpenAPI.BASE = envs?.[1] ?? ''
       return id ?? ''

--- a/store/account.ts
+++ b/store/account.ts
@@ -86,6 +86,7 @@ export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
   removeOngoingTransaction: () => {
     set({
       ongoingBridgeTx: undefined,
+      lastOngoingPaymentIdFromTU: '',
     })
   },
   setWrapTokenFeePercentageBps: (fee: number) => {

--- a/store/account.ts
+++ b/store/account.ts
@@ -85,8 +85,6 @@ export const useTariAccount = create<TariL1WalletStoreState>()((set) => ({
     })
   },
   removeOngoingTransaction: () => {
-    console.error('[ TAPPLET-BRIDGE ] remove Ongoing TX store')
-
     set({
       ongoingBridgeTx: undefined,
       isOngoingBridgeTx: false,

--- a/utils/transaction.ts
+++ b/utils/transaction.ts
@@ -1,10 +1,11 @@
+import { BridgeInfo } from '@/hooks/use-bridge-info'
 import { BridgeToEthereumFees } from '@/hooks/use-bridge-to-ethereum-fees'
 import { PendingUserTransaction } from '@/types/tapplet'
 import { UserTransactionDTO } from '@tari-project/wxtm-bridge-backend-api'
 import { formatUnits } from 'ethers'
 
 export function getModalTitle(
-  fromToken: string,
+  bridgeInfo: BridgeInfo,
   feeData: BridgeToEthereumFees,
   tx?: PendingUserTransaction,
 ): { title: string; subtext: string } {
@@ -17,16 +18,20 @@ export function getModalTitle(
   const amount = parseFloat(
     formatUnits(tx.tokenAmount, 6).toString(),
   ).toPrecision()
-  const isUnwrapping = fromToken === 'wXTM'
+  const amountToReceive = parseFloat(
+    formatUnits(tx.amountAfterFee, 6).toString(),
+  ).toPrecision()
   const bridgingTime = feeData.isOverHighBridgeThreshold ? '24-72h' : '12h'
+  const txDirection = bridgeInfo.isWrapping ? 'wrapping' : 'unwrapping'
+  const [fromNetwork, toNetwork] = bridgeInfo.isWrapping
+    ? ['Tari', 'Ethereum']
+    : ['Ethereum', 'Tari']
 
   switch (tx.status) {
     case UserTransactionDTO.status.PENDING:
       return {
-        title: `We're ${
-          isUnwrapping ? 'unwrapping' : 'wrapping'
-        } your ${amount} ${fromToken}`,
-        subtext: `You'll receive ${amount} ${fromToken} in no more than ${bridgingTime}.  Funds are automatically transferred from your linked Tari Universe wallet. You don't need to do anything else.`,
+        title: `We're ${txDirection} your ${amount} ${bridgeInfo.fromToken}`,
+        subtext: `You'll receive ${amountToReceive} ${bridgeInfo.toToken} in no more than ${bridgingTime}. Funds are automatically transferred from your linked ${fromNetwork} wallet. You don't need to do anything else.`,
       }
     case UserTransactionDTO.status.PROCESSING:
       return {
@@ -35,20 +40,18 @@ export function getModalTitle(
       }
     case UserTransactionDTO.status.SUCCESS:
       return {
-        title: `We've ${
-          isUnwrapping ? 'unwrapped' : 'wrapped'
-        } your ${amount} ${fromToken}!`,
-        subtext: `Your wXTM conversion has been complete and your funds have been deposited into the address specified.`,
+        title: `We've ${txDirection} your ${amount} ${bridgeInfo.fromToken}!`,
+        subtext: `Your ${bridgeInfo.toToken} conversion has been complete and your funds have been deposited into the address specified.`,
       }
     case UserTransactionDTO.status.TIMEOUT:
       return {
         title: `Oops! Your transaction has timed out!`,
-        subtext: `We couldn't complete your wrapping request in time. Your XTM remains safe in your Tari wallet — it hasn't been deducted or moved.`,
+        subtext: `We couldn't complete your ${txDirection} request in time. Your ${bridgeInfo.fromToken} remains safe in your ${fromNetwork} wallet — it hasn't been deducted or moved.`,
       }
     case UserTransactionDTO.status.TOKENS_RECEIVED:
       return {
-        title: `${fromToken} received - wrapping soon`,
-        subtext: `We've received your ${fromToken}. Wrapping is queued and will begin shortly. You'll get wXTM at your Ethereum address once complete.`,
+        title: `${amount} ${bridgeInfo.fromToken} received - ${txDirection} soon`,
+        subtext: `We've received your ${bridgeInfo.fromToken}: ${txDirection} is queued and will begin shortly. You'll get ${bridgeInfo.toToken} at your  ${toNetwork} address once complete.`,
       }
     default:
       return {


### PR DESCRIPTION
Description
---
It may happen that the tari transaction initiating the bridging process is not sent, and therefore the user waits for the first review modal, which seems to be an error. As a fix, jump directly to the second modal so that the information that bridging is in progress is visible.

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
