### PR TITLE
feat: attach base node status before and after sending

### DIFF
--- a/clients/tari-l1-signer.ts
+++ b/clients/tari-l1-signer.ts
@@ -14,6 +14,18 @@ export interface SendOneSidedRequest {
   paymentId?: string
 }
 
+export interface BaseNodeStatus {
+  sha_network_hashrate: number
+  monero_randomx_network_hashrate: number
+  tari_randomx_network_hashrate: number
+  block_reward: number
+  block_height: number
+  block_time: number
+  is_synced: boolean
+  num_connections: number
+  readiness_status: string
+}
+
 export interface BridgeTxDetails {
   amount: string
   amountToReceive: string
@@ -95,6 +107,17 @@ export class TariL1Signer {
     return this.sendRequest({
       methodName: 'sendOneSided',
       args: [{ amount, address, paymentId }],
+    })
+  }
+
+  /**
+   * @description get Base Node status
+   * @returns BaseNodeStatus
+   */
+  public async getBaseNodeStatus(): Promise<BaseNodeStatus> {
+    return this.sendRequest({
+      methodName: 'getBaseNodeStatus',
+      args: [],
     })
   }
 

--- a/hooks/use-bridge-to-ethereum.ts
+++ b/hooks/use-bridge-to-ethereum.ts
@@ -44,10 +44,12 @@ export const useBridgeToEthereum = () => {
 
     const parsedAmount = parseWxtmTokenAmount(amount)
 
+    const baseNodeStatusBefore = await signer?.getBaseNodeStatus()
     const { paymentId } = await createTransaction.mutateAsync({
       to: ethAddress,
       from: tariAccount.address,
       tokenAmount: parsedAmount,
+      debug: { ...baseNodeStatusBefore },
     })
 
     // set ongoing to immediately display wrap modal
@@ -82,7 +84,10 @@ export const useBridgeToEthereum = () => {
       console.error('[ TAPPLET-BRIDGE ] send one sided failed')
     }
 
-    const { success } = await confirmTokenSent.mutateAsync(paymentId)
+    const baseNodeStatusAfter = await signer?.getBaseNodeStatus()
+    const { success } = await confirmTokenSent.mutateAsync(paymentId, {
+      debug: { ...baseNodeStatusAfter },
+    })
     if (!success) {
       console.error('[ TAPPLET-BRIDGE ] confirm token sent failed')
     }


### PR DESCRIPTION
Requires https://github.com/tari-project/universe/pull/2449 to be merged

Description
---
For observing base node status when wrapping XTM 

* Exposed for Tapplet use
* Update with new BaseNodeStatus type properties

Example response:
```ts
block_height: 46009
block_reward: 13399875729
block_time: 1750933785
is_synced: true
monero_randomx_network_hashrate: 13249
num_connections: 26
readiness_status: 0
sha_network_hashrate: 24614943
tari_randomx_network_hashrate: 0
```
----
I want to save it in the `debug` property in the bridge method:

```ts
    const { paymentId } = await createTransaction.mutateAsync({
      to: ethAddress,
      from: tariAccount.address,
      tokenAmount: parsedAmount,
      debug: { ...baseNodeStatusBefore }
    })
```

```ts
    const { success } = await confirmTokenSent.mutateAsync(paymentId, {
      debug: { ...baseNodeStatusAfter },
    })
 ```
