### PR TITLE
fix: bridge max amount validation

### DIFF
--- a/components/bridge-form/bridge-form.component.tsx
+++ b/components/bridge-form/bridge-form.component.tsx
@@ -104,6 +104,12 @@ export const BridgeForm: React.FC<MainComponentProps> = ({
         : (availableBalance / 1_000_000).toString()
       : evm_balance
   }
+  
+   
+  const inputAvailableBalance = () =>
+    fromNetwork.name === 'Tari'
+      ? availableBalance / 1000000
+      : (Number(data?.value) ?? 0) / Math.pow(10, 18)
 
   return (
     <div className="bg-white/50 backdrop-blur-sm shadow-xl rounded-2xl p-4 mx-auto min-h-[130px] fixed-box mb-5">
@@ -164,6 +170,7 @@ export const BridgeForm: React.FC<MainComponentProps> = ({
                         fromNetwork={fromNetwork}
                         control={control}
                         errors={errors}
+                        availableBalance={inputAvailableBalance()}
                       />
                     </div>
                     <div className="hidden lg:flex flex-col">

--- a/components/bridge-input/bridge-input.tsx
+++ b/components/bridge-input/bridge-input.tsx
@@ -5,16 +5,15 @@ import { TextField } from '@mui/material'
 import { BridgeInputProps } from './bridge-input.types'
 import { useBridgeInfo } from '@/hooks/use-bridge-info'
 import { config } from '@/config'
-import useTariAccountStore from '@/store/account'
 
 export const BridgeInput: React.FC<BridgeInputProps> = ({
   fromNetwork,
   control,
   errors,
+  availableBalance,
 }) => {
   const [valueLength, setValueLength] = useState(5)
   const { fromToken } = useBridgeInfo(fromNetwork)
-  const availableBalance = useTariAccountStore((s) => s.availableBalance)
 
   // Helper to block invalid keys
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/components/bridge-input/bridge-input.types.ts
+++ b/components/bridge-input/bridge-input.types.ts
@@ -9,4 +9,5 @@ export type BridgeInputProps = {
   fromNetwork: Network
   control: Control<BridgeFormValues>
   errors: FieldErrors<BridgeFormValues>
+  availableBalance: number,
 }

--- a/components/main/footer-text.tsx
+++ b/components/main/footer-text.tsx
@@ -10,7 +10,6 @@ export const FooterText: React.FC = ({}) => {
 
   return (
     <div className="fixed bottom-0 mb-4 left-0 w-full text-center text-xs text-black/50 items-center justify-center whitespace-pre-line leading-[200%]">
-      {t('bridge_one_way_notice')}{' '}
       <a
         onClick={(e) => openExternalLink(config.TARI_BRIDGE_FAQ_URL, e)}
         rel="noopener noreferrer"


### PR DESCRIPTION
Description
---

Bridge can do wrap and unwrap operations. We need to restrict user from attempting to do either operation with amount, that exceeds the amount that is available in his wallet.

<img width="1380" height="227" alt="Screenshot 2025-09-29 at 14 39 10" src="https://github.com/user-attachments/assets/834bba6f-0447-46d3-a02b-266e34125d2b" />

This PR also removes one way notice:
```
Tari Bridge currently operates one way (XTM to wXTM). Tari contributors expect to launch wXTM unwrapping in July 2025 or sooner.
```

Motivation and Context
---

Existing validation was implemented only for wrapping, and even there it did not function correctly, since available amount was in microTari. Thus the tapplet accepted amounts which exceed available balance in Tari wallet.

This change also adjusts the max available balance depending on operation:
- _wrap_ - take available amount from Tari wallet
- _unwrap_ - take available amount from connected Ethereum wallet

How Has This Been Tested?
---

Build and copy to Tari Universe cache.
```sh
wxtm-bridge-frontend$ npm run build
wxtm-bridge-frontend$ cp out/ ~/Library/Caches/com.tari.universe.alpha/tapplets/bridge/esmeralda/0.2.0
wxtm-bridge-frontend$
```

Run Tari Universe:
```sh
universe$ npm run tauri dev
```

What process can a PR reviewer use to test or verify this change?
---

Similar as above.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
