### PR TITLE
fix: restrict Ethereum chains based on Tari Universe network

### DIFF
--- a/clients/tari-l1-signer.ts
+++ b/clients/tari-l1-signer.ts
@@ -198,6 +198,13 @@ export class TariL1Signer {
       args: [],
     })
   }
+
+  public async getNetwork(): Promise<string | undefined> {
+    return this.sendRequest({
+      methodName: 'getNetwork',
+      args: [],
+    })
+  }
 }
 
 function sendSignerCall<MethodName extends SignerMethodNames>(

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -5,23 +5,26 @@ import Image from 'next/image'
 import { useAccount, useChainId } from 'wagmi'
 import { truncateAddress } from '@/utils/truncate'
 import { NetworkSwitchModal } from '@/components/modals/network-switch-modal'
-import { supportedChains, chainsMap } from '@/utils/networksConfig'
+import { chainsMap } from '@/utils/networksConfig'
 import { HeaderProps } from './header.types'
 import { BridgeHistoryListItem } from '../transactions/BridgeListItem'
 import useTariAccountStore from '@/store/account'
 import { useBridgeStatus } from '@/hooks/use-bridge-status'
+import useAppStore from '@/store/app'
 
 export const Header = ({ onConnectClickAction }: HeaderProps) => {
+  const { getSupportedChains } = useAppStore()
   const chainId = useChainId()
   const { address, isConnected, chain } = useAccount()
   const [showNetworkModal, setShowNetworkModal] = useState(false)
   const bridgeTxs = useTariAccountStore((s) => s.combinedBridgeTxs)
   const exampleItem = bridgeTxs.find((tx) => tx.paymentId !== '')
   const setDetailedTx = useTariAccountStore((s) => s.setDetailedTx)
+  const supportedChains = getSupportedChains();
 
   const { isOffline } = useBridgeStatus()
 
-  const isNetworkSupported = chain !== undefined
+  const isNetworkSupported = chain !== undefined && supportedChains.some((c) => c.id === chain.id)
   const handleDisplayTransaction = () => {
     if (exampleItem) {
       setDetailedTx(exampleItem)

--- a/store/app.ts
+++ b/store/app.ts
@@ -3,6 +3,7 @@ import useTariSigner from './signer'
 import { OpenAPI } from '@tari-project/wxtm-bridge-backend-api'
 import i18next, { changeLanguage } from 'i18next'
 import { parseTheme, Theme } from '@/types/app'
+import { SupportedChain, supportedChains } from '@/utils/networksConfig'
 
 interface State {
   language: string
@@ -19,6 +20,7 @@ interface Actions {
   setLanguage: (language: string) => Promise<void>
   setTheme: (theme: string) => void
   setUnwrapEnabled: (unwrapEnabled: boolean) => void
+  getSupportedChains: () => SupportedChain[]
 }
 
 type AppStoreState = State & Actions
@@ -33,7 +35,7 @@ const initialState: State = {
   isMainNet: true,
 }
 
-export const useAppStore = create<AppStoreState>()((set) => ({
+export const useAppStore = create<AppStoreState>()((set, get) => ({
   ...initialState,
   setAppConfig: async () => {
     const signer = useTariSigner.getState().signer
@@ -99,6 +101,10 @@ export const useAppStore = create<AppStoreState>()((set) => ({
     set({
       hideWalletBalance: hideBalance,
     })
+  },
+  getSupportedChains: () => {
+    const { isMainNet } = get()
+    return isMainNet ? supportedChains.filter((c) => c.id === 1) : supportedChains.filter((c) => c.id !== 1)
   },
 }))
 

--- a/store/app.ts
+++ b/store/app.ts
@@ -11,6 +11,7 @@ interface State {
   theme: Theme
   hideWalletBalance: boolean
   unwrapEnabled: boolean
+  isMainNet: boolean
 }
 
 interface Actions {
@@ -29,6 +30,7 @@ const initialState: State = {
   theme: 'light',
   hideWalletBalance: false,
   unwrapEnabled: false,
+  isMainNet: true,
 }
 
 export const useAppStore = create<AppStoreState>()((set) => ({
@@ -42,6 +44,9 @@ export const useAppStore = create<AppStoreState>()((set) => ({
         return
       }
 
+      const network = await signer.getNetwork()
+      const isMainNet = network?.toLowerCase() === 'mainnet'
+
       const envs =
         process.env.NODE_ENV === 'development'
           ? [process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID, process.env.NEXT_PUBLIC_BACKEND_API_URL]
@@ -52,6 +57,7 @@ export const useAppStore = create<AppStoreState>()((set) => ({
       set({
         walletConnectProjectId: walletconnectId,
         bridgeAPI: bridgeAPI,
+        isMainNet,
       })
 
       // set OpenAPI configuration

--- a/utils/networksConfig.ts
+++ b/utils/networksConfig.ts
@@ -1,4 +1,10 @@
-export const supportedChains = [
+export interface SupportedChain {
+  id: number
+  name: string
+  icon: string
+}
+
+export const supportedChains: SupportedChain[] = [
   {
     id: 1,
     name: 'ETH MAINNET',


### PR DESCRIPTION
Description
---

Restricts Ethereum wallet chain based on Tari Universe network.
The modal window with available networks will be shown **only** if your selected network (in Metamask) is not supported.

https://github.com/user-attachments/assets/c4f39435-c5f1-42ba-b539-e64b2a010f5d


Motivation and Context
---

Up until now, the Bridge tapplet had 3 supported chains:
- ETH MAINNET
- SEPOLIA
- BASE SEPOLIA

And regardless of Tari Universe network (mainnet or testnet/esmeralda), it allowed to use any of these 3 Ethereum chains.

This change restricts it.
If you are on Tari Mainnet, you can use only ETH MAINNET.
If you are on other Tari network, you can use either SEPOLIA or BASE SEPOLIA

**IMPORTANT! This PR depends on Tari Universe `getNetwork` call, which was added in this Tari Universe [PR](https://github.com/tari-project/universe/pull/3064)**

How Has This Been Tested?
---

Locally

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
