### PR TITLE
fix: use correct store value for limit alert

### DIFF
--- a/components/main/main.component.tsx
+++ b/components/main/main.component.tsx
@@ -10,13 +10,14 @@ import { HomeText } from './home-text'
 import { useTariAccountStore } from '@/store/account'
 
 import { useBridgeStatus } from '@/hooks/use-bridge-status'
+import { useBridgeStore } from '@/store/bridge'
 
 // TODO - add translation keys
 
 export const MainComponent = ({ remainingDailyLimit }: MainComponentProps) => {
   const { t } = useTranslation('main', { useSuspense: false })
   const [showHistory, setShowHistory] = useState(false)
-  const exceededDailyLimit = useTariAccountStore((s) => s.exceededDailyLimit)
+  const exceededDailyLimit = useBridgeStore((s) => s.exceededDailyLimit)
   const bridgeTxs = useTariAccountStore((s) => s.combinedBridgeTxs)
 
   const { isOffline } = useBridgeStatus()
@@ -39,9 +40,9 @@ export const MainComponent = ({ remainingDailyLimit }: MainComponentProps) => {
   const mainMarkup = !isOffline ? (
     <div className="mt-6">
       {exceededDailyLimit && (
-        <div className="flex items-center justify-center w-[clamp(450px,45vw,60%)]">
-          <div className="py-4 px-2 rounded-2xl bg-white/25 backdrop-blur-sm shadow-lg">
-            <div className="font-normal leading-none text-lg text-center text-balance ">
+        <div className="flex items-center justify-center w-[clamp(480px,50vw,800px)]">
+          <div className="p-4 rounded-2xl bg-white/25 backdrop-blur-sm shadow-lg">
+            <div className="font-light leading-none text-[16px] text-center text-pretty text-balance">
               We cannot process your transaction because{' '}
               <span className="font-medium">the transaction limit has been reached for the day.</span> Please try again
               tomorrow.

--- a/components/modals/main-modal/main-modal.tsx
+++ b/components/modals/main-modal/main-modal.tsx
@@ -58,12 +58,12 @@ export const MainModal = ({
         setExceededDailyLimit(false)
       })
       .catch((e) => {
-        console.error('[ TAPPLET-BRIDGE ] Bridge operation failed:', e)
         const error = e as Error
         const isLimitError =
-          error?.message?.includes(DAILY_LIMIT_ERROR_TYPE) || error?.message?.includes(DAILY_LIMIT_ERROR)
-        setExceededDailyLimit(isLimitError)
+          error?.message?.includes(DAILY_LIMIT_ERROR) || error?.message?.includes(DAILY_LIMIT_ERROR_TYPE)
         if (isLimitError) {
+          console.warn('[ TAPPLET-BRIDGE ] Bridge operation failed:', e)
+          setExceededDailyLimit(true)
           setIsModalOpen(false)
         }
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wxtm-bridge-frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/store/account.ts
+++ b/store/account.ts
@@ -32,7 +32,7 @@ export const useTariAccountStore = create<TariL1WalletStoreState>()(() => ({
 }))
 
 export const setTariAccount = async () => {
-  // if (process.env.NODE_ENV === 'development') return
+  if (process.env.NODE_ENV === 'development') return
 
   const signer = useTariSigner.getState().signer
 

--- a/store/account.ts
+++ b/store/account.ts
@@ -12,7 +12,6 @@ interface TariL1WalletStoreState {
   backendUnwrapTxs: BackendUnwrapTransaction[]
   combinedBridgeTxs: CombinedBridgeTransaction[]
   detailedTx?: CombinedBridgeTransaction | null
-  exceededDailyLimit: boolean
 }
 
 const initialState: TariL1WalletStoreState = {
@@ -26,7 +25,6 @@ const initialState: TariL1WalletStoreState = {
   backendBridgeTxs: [],
   backendUnwrapTxs: [],
   combinedBridgeTxs: [],
-  exceededDailyLimit: false,
 }
 
 export const useTariAccountStore = create<TariL1WalletStoreState>()(() => ({
@@ -34,7 +32,7 @@ export const useTariAccountStore = create<TariL1WalletStoreState>()(() => ({
 }))
 
 export const setTariAccount = async () => {
-  if (process.env.NODE_ENV === 'development') return
+  // if (process.env.NODE_ENV === 'development') return
 
   const signer = useTariSigner.getState().signer
 
@@ -115,5 +113,3 @@ export const setDetailedTx = (detailedTx: CombinedBridgeTransaction | null) =>
   useTariAccountStore.setState({
     detailedTx: detailedTx,
   })
-export const setExceededDailyLimit = (exceededDailyLimit: boolean) =>
-  useTariAccountStore.setState({ exceededDailyLimit })


### PR DESCRIPTION
Description
---
- accidentally left in the old store values for the limit error in #100 
  - used the correct one from `useBridgeStore`
  - removed the old items from account store

Motivation and Context
---

- daily limit warning wasn't coming up in TU 😬 

How Has This Been Tested?
---

- locally (built and moved over to binaries' location to test in TU)




https://github.com/user-attachments/assets/80293015-29e7-4c99-8b09-08bc9d38441e



