### PR TITLE
fix: add Ethereum RPC failover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=''
 NEXT_PUBLIC_BACKEND_API_URL=http://localhost:3001
+NEXT_PUBLIC_ETHEREUM_MAINNET_RPC_URLS=https://ethereum-rpc.publicnode.com,https://eth-mainnet.public.blastapi.io,https://eth.drpc.org

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,14 +1,28 @@
 import useAppStore from '@/store/app'
-import { http, createConfig, createStorage, cookieStorage } from 'wagmi'
+import { fallback, http, createConfig, createStorage, cookieStorage } from 'wagmi'
 import { mainnet, baseSepolia, sepolia } from 'wagmi/chains'
 import { walletConnect } from 'wagmi/connectors'
+
+const defaultMainnetRpcUrls = [
+  'https://ethereum-rpc.publicnode.com',
+  'https://eth-mainnet.public.blastapi.io',
+  'https://eth.drpc.org',
+]
+
+const configuredMainnetRpcUrls = process.env.NEXT_PUBLIC_ETHEREUM_MAINNET_RPC_URLS?.split(',')
+  .map((url) => url.trim())
+  .filter(Boolean)
+
+const mainnetRpcUrls = configuredMainnetRpcUrls?.length ? configuredMainnetRpcUrls : defaultMainnetRpcUrls
+
+const mainnetTransports = fallback(mainnetRpcUrls.map((url) => http(url)))
 
 export function getConfig(id?: string) {
   const projectId = id || useAppStore.getState().walletConnectProjectId
   return createConfig({
     chains: [mainnet, baseSepolia, sepolia],
     transports: {
-      [mainnet.id]: http(),
+      [mainnet.id]: mainnetTransports,
       [sepolia.id]: http(),
       [baseSepolia.id]: http(),
     },


### PR DESCRIPTION
## Summary
- Replace the default Ethereum mainnet transport with an explicit wagmi/viem fallback transport.
- Add public RPC fallbacks for mainnet reads so the app is not dependent on viem's default `eth.merkle.io` endpoint.
- Leave Sepolia and Base Sepolia transports unchanged.

Fixes #102

## Verification
- Confirmed `fallback` is exported by `wagmi@3.3.2` via the package tarball types and ESM exports.
- `git diff --check`
- Verified the selected RPCs with the issue's `eth_call` payload:
  - `https://ethereum-rpc.publicnode.com` returned a successful result
  - `https://eth-mainnet.public.blastapi.io` returned a successful result
  - `https://eth.drpc.org` returned a successful result

## Local build note
- Full `npm ci` / `npm run build` is blocked locally by the private GitHub Packages dependency `@tari-project/wxtm-bridge-contracts@0.1.12` returning `401 Unauthorized` without a package token.
