### PR TITLE
security: Add Auto-Disconnect on Idle Timeout

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useState, useEffect, useRef, useEffectEvent } from 'react'
 import { WagmiProvider, State, Config, cookieToInitialState } from 'wagmi'
+import { useIdleTimeout } from '@/hooks/use-idle-timeout'
 import { getConfig } from '@/utils/config'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { setTariAccount } from '@/store/account'
@@ -69,6 +70,7 @@ export const Providers = ({ children }: { children: ReactNode }) => {
   }, [signer])
 
   useIframeMessage()
+  useIdleTimeout()
 
   if (!config) {
     return <div className="h-5 w-5 animate-spin rounded-full border-b-[3px] border-white" />

--- a/hooks/use-idle-timeout.ts
+++ b/hooks/use-idle-timeout.ts
@@ -1,0 +1,40 @@
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useDisconnect } from 'wagmi';
+
+const IDLE_TIMEOUT = 15 * 60 * 1000; // 15 minutes in milliseconds
+
+export function useIdleTimeout() {
+  const { disconnect } = useDisconnect();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const resetTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      console.log('User idle for too long, disconnecting wallet.');
+      disconnect();
+    }, IDLE_TIMEOUT);
+  }, [disconnect]);
+
+  useEffect(() => {
+    // Set up initial timer
+    resetTimer();
+
+    const events = ['mousemove', 'keydown', 'scroll', 'click'];
+
+    events.forEach(event => {
+      window.addEventListener(event, resetTimer);
+    });
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      events.forEach(event => {
+        window.removeEventListener(event, resetTimer);
+      });
+    };
+  }, [resetTimer]);
+}

--- a/hooks/use-idle-timeout.ts
+++ b/hooks/use-idle-timeout.ts
@@ -6,14 +6,13 @@ const IDLE_TIMEOUT = 15 * 60 * 1000; // 15 minutes in milliseconds
 
 export function useIdleTimeout() {
   const { disconnect } = useDisconnect();
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const resetTimer = useCallback(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
     timeoutRef.current = setTimeout(() => {
-      console.log('User idle for too long, disconnecting wallet.');
       disconnect();
     }, IDLE_TIMEOUT);
   }, [disconnect]);


### PR DESCRIPTION
Implemented a global listener that automatically disconnects the user's Web3 wallet after 15 minutes of inactivity (no mouse movement, clicks, or keystrokes) to protect funds if a user walks away from their device.