### PR TITLE
feat: Add Fallback UI for Broken Token Images

### DIFF
--- a/components/bridge-form/bridge-form.component.tsx
+++ b/components/bridge-form/bridge-form.component.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import Image from 'next/image'
+import { FallbackImage } from '@/components/fallback-image'
 import { erc20Abi } from 'viem'
 import { useConnection, useReadContract } from 'wagmi'
 import { FaArrowRight } from 'react-icons/fa6'
@@ -172,7 +172,7 @@ export const BridgeForm = ({ remainingDailyLimit }: MainComponentProps) => {
                     <div className="hidden lg:flex flex-col">
                       <div className="w-fit flex py-1 2xl:py-2 px-3 bg-gray-200 items-center rounded-3xl justify-center self-end">
                         <div className="w-5 h-5 rounded-full overflow-hidden -ml-1 mr-2 relative">
-                          <Image
+                          <FallbackImage
                             src={fromNetwork.icon}
                             fill
                             sizes="20px"
@@ -180,11 +180,7 @@ export const BridgeForm = ({ remainingDailyLimit }: MainComponentProps) => {
                               network: fromNetwork.name,
                             })}
                             className="rounded-full object-cover"
-                            onError={(e) => {
-                              ;(e.target as HTMLImageElement).srcset = ''
-                              ;(e.target as HTMLImageElement).src =
-                                'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"%3E%3Ccircle cx="10" cy="10" r="10" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="10" y="14" font-family="Arial" font-size="12" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
-                            }}
+                            fallbackSvg='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"%3E%3Ccircle cx="10" cy="10" r="10" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="10" y="14" font-family="Arial" font-size="12" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
                           />
                         </div>
                         <div className="font-bold text-[12.85px]">{fromToken}</div>

--- a/components/bridge-form/bridge-form.component.tsx
+++ b/components/bridge-form/bridge-form.component.tsx
@@ -180,6 +180,11 @@ export const BridgeForm = ({ remainingDailyLimit }: MainComponentProps) => {
                               network: fromNetwork.name,
                             })}
                             className="rounded-full object-cover"
+                            onError={(e) => {
+                              ;(e.target as HTMLImageElement).srcset = ''
+                              ;(e.target as HTMLImageElement).src =
+                                'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"%3E%3Ccircle cx="10" cy="10" r="10" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="10" y="14" font-family="Arial" font-size="12" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
+                            }}
                           />
                         </div>
                         <div className="font-bold text-[12.85px]">{fromToken}</div>

--- a/components/fallback-image/fallback-image.component.tsx
+++ b/components/fallback-image/fallback-image.component.tsx
@@ -1,0 +1,21 @@
+
+
+import React from 'react';
+import Image from 'next/image';
+import { ImageProps } from 'next/image';
+
+interface FallbackImageProps extends ImageProps {
+  fallbackSvg: string;
+}
+
+export const FallbackImage: React.FC<FallbackImageProps> = ({ fallbackSvg, onError, ...props }) => {
+  const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    e.currentTarget.onerror = null; // Prevent infinite loop
+    e.currentTarget.srcset = '';
+    e.currentTarget.src = fallbackSvg;
+    onError?.(e); // Call original onError if provided
+  };
+
+  return <Image {...props} onError={handleImageError} />;
+};
+

--- a/components/fallback-image/index.ts
+++ b/components/fallback-image/index.ts
@@ -1,0 +1,4 @@
+
+
+export * from './fallback-image.component';
+

--- a/components/modals/network-switch-modal/network-switch-modal.tsx
+++ b/components/modals/network-switch-modal/network-switch-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Image from 'next/image'
+import { FallbackImage } from '@/components/fallback-image'
 import { useSwitchChain } from 'wagmi'
 import { IoCloseOutline } from 'react-icons/io5'
 import { NetworkSwitchModalProps } from './network-switch-modal.types'
@@ -42,17 +42,13 @@ export const NetworkSwitchModal = ({ closeModalAction, supportedChains }: Networ
                 className="hover:bg-gray-200/80 hover:cursor-pointer p-4 font-medium w-full text-left flex items-center gap-3"
               >
                 <div className="w-[36px] h-[36px] rounded-full overflow-hidden relative flex-shrink-0">
-                  <Image
+                  <FallbackImage
                     src={chain.icon}
                     fill
                     sizes="36px"
                     alt={`${chain.name} icon`}
                     className="object-cover"
-                    onError={(e) => {
-                      ;(e.target as HTMLImageElement).srcset = ''
-                      ;(e.target as HTMLImageElement).src =
-                        'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36"%3E%3Ccircle cx="18" cy="18" r="18" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="18" y="24" font-family="Arial" font-size="18" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
-                    }}
+                    fallbackSvg='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36"%3E%3Ccircle cx="18" cy="18" r="18" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="18" y="24" font-family="Arial" font-size="18" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
                   />
                 </div>
                 <div>

--- a/components/modals/network-switch-modal/network-switch-modal.tsx
+++ b/components/modals/network-switch-modal/network-switch-modal.tsx
@@ -42,7 +42,18 @@ export const NetworkSwitchModal = ({ closeModalAction, supportedChains }: Networ
                 className="hover:bg-gray-200/80 hover:cursor-pointer p-4 font-medium w-full text-left flex items-center gap-3"
               >
                 <div className="w-[36px] h-[36px] rounded-full overflow-hidden relative flex-shrink-0">
-                  <Image src={chain.icon} fill sizes="36px" alt={`${chain.name} icon`} className="object-cover" />
+                  <Image
+                    src={chain.icon}
+                    fill
+                    sizes="36px"
+                    alt={`${chain.name} icon`}
+                    className="object-cover"
+                    onError={(e) => {
+                      ;(e.target as HTMLImageElement).srcset = ''
+                      ;(e.target as HTMLImageElement).src =
+                        'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36"%3E%3Ccircle cx="18" cy="18" r="18" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="18" y="24" font-family="Arial" font-size="18" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
+                    }}
+                  />
                 </div>
                 <div>
                   <div className="font-bold">{chain.name}</div>

--- a/components/network-box/network-box.tsx
+++ b/components/network-box/network-box.tsx
@@ -25,7 +25,18 @@ export const NetworkBox = ({ type, selected, isOpen, networks, onToggle, onSelec
     <div className="relative">
       <div className="flex items-center gap-3 p-2 px-4 bg-white rounded-xl border border-gray-200 min-h-[90px] max-h-[90px]">
         <div className="w-[38px] h-[38px] relative rounded-full overflow-hidden ml-3">
-          <Image src={selected.icon} fill alt={selected.name} sizes="38px" className="object-cover rounded-full" />
+          <Image
+            src={selected.icon}
+            fill
+            alt={selected.name}
+            sizes="38px"
+            className="object-cover rounded-full"
+            onError={(e) => {
+              ;(e.target as HTMLImageElement).srcset = ''
+              ;(e.target as HTMLImageElement).src =
+                'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38"%3E%3Ccircle cx="19" cy="19" r="19" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="19" y="25" font-family="Arial" font-size="20" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
+            }}
+          />
         </div>
         <div className="flex flex-col text-xs text-gray-500 font-medium">
           <div>{type === 'from' ? 'From' : 'To'}</div>
@@ -47,7 +58,18 @@ export const NetworkBox = ({ type, selected, isOpen, networks, onToggle, onSelec
               onClick={() => onSelect(network)}
             >
               <div className="w-6 h-6 relative">
-                <Image src={network.icon} fill alt={network.name} sizes="24px" className="object-cover rounded-full" />
+                <Image
+                  src={network.icon}
+                  fill
+                  alt={network.name}
+                  sizes="24px"
+                  className="object-cover rounded-full"
+                  onError={(e) => {
+                    ;(e.target as HTMLImageElement).srcset = ''
+                    ;(e.target as HTMLImageElement).src =
+                      'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Ccircle cx="12" cy="12" r="12" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="12" y="16" font-family="Arial" font-size="14" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
+                  }}
+                />
               </div>
               <span className="text-sm font-medium text-gray-800">{network.name}</span>
             </div>

--- a/components/network-box/network-box.tsx
+++ b/components/network-box/network-box.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Image from 'next/image'
+import { FallbackImage } from '@/components/fallback-image'
 import { IoIosArrowUp, IoIosArrowDown } from 'react-icons/io'
 
 import { NetworkBoxProps } from './network-box.types'
@@ -25,17 +25,13 @@ export const NetworkBox = ({ type, selected, isOpen, networks, onToggle, onSelec
     <div className="relative">
       <div className="flex items-center gap-3 p-2 px-4 bg-white rounded-xl border border-gray-200 min-h-[90px] max-h-[90px]">
         <div className="w-[38px] h-[38px] relative rounded-full overflow-hidden ml-3">
-          <Image
+          <FallbackImage
             src={selected.icon}
             fill
             alt={selected.name}
             sizes="38px"
             className="object-cover rounded-full"
-            onError={(e) => {
-              ;(e.target as HTMLImageElement).srcset = ''
-              ;(e.target as HTMLImageElement).src =
-                'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38"%3E%3Ccircle cx="19" cy="19" r="19" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="19" y="25" font-family="Arial" font-size="20" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
-            }}
+            fallbackSvg='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="38" height="38" viewBox="0 0 38 38"%3E%3Ccircle cx="19" cy="19" r="19" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="19" y="25" font-family="Arial" font-size="20" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
           />
         </div>
         <div className="flex flex-col text-xs text-gray-500 font-medium">
@@ -58,17 +54,13 @@ export const NetworkBox = ({ type, selected, isOpen, networks, onToggle, onSelec
               onClick={() => onSelect(network)}
             >
               <div className="w-6 h-6 relative">
-                <Image
+                <FallbackImage
                   src={network.icon}
                   fill
                   alt={network.name}
                   sizes="24px"
                   className="object-cover rounded-full"
-                  onError={(e) => {
-                    ;(e.target as HTMLImageElement).srcset = ''
-                    ;(e.target as HTMLImageElement).src =
-                      'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Ccircle cx="12" cy="12" r="12" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="12" y="16" font-family="Arial" font-size="14" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
-                  }}
+                  fallbackSvg='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Ccircle cx="12" cy="12" r="12" fill="%23ccc"%3E%3C/circle%3E%3Ctext x="12" y="16" font-family="Arial" font-size="14" fill="%23fff" text-anchor="middle"%3E%3F%3C/text%3E%3C/svg%3E'
                 />
               </div>
               <span className="text-sm font-medium text-gray-800">{network.name}</span>


### PR DESCRIPTION
Added onError event handlers to Next.js Image components. If a token logo URL is broken or fails to load, it elegantly falls back to a generic SVG placeholder, preventing broken UI states.