### PR TITLE
fix: pin next and eslint-config-next to exact version 16.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
     "motion": "^12.26.2",
-    "next": "^16.1.1",
+    "next": "16.1.7",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.1",
@@ -40,7 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "@walletconnect/ethereum-provider": "^2.23.2",
     "eslint": "^9.39.2",
-    "eslint-config-next": "^16.1.1",
+    "eslint-config-next": "16.1.7",
     "eslint-plugin-i18next": "^6.1.3",
     "tailwindcss": "^4",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Pins next and eslint-config-next to exactly 16.1.7 (removing ^ caret) to mitigate CVE risks from semver-resolved vulnerable versions.

Closes #103

Description
---

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
