### PR TITLE
Pin next + eslint-config-next to 16.1.7 (CVE mitigation, closes #103)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
     "motion": "^12.26.2",
-    "next": "^16.1.1",
+    "next": "16.1.7",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.1",
@@ -40,7 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "@walletconnect/ethereum-provider": "^2.23.2",
     "eslint": "^9.39.2",
-    "eslint-config-next": "^16.1.1",
+    "eslint-config-next": "16.1.7",
     "eslint-plugin-i18next": "^6.1.3",
     "tailwindcss": "^4",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Closes #103

## Summary
Pins `next` and `eslint-config-next` to exactly `16.1.7` in `package.json` so the resolver cannot fall back to a vulnerable 16.x patch version. The carets `^` are removed.

## Acceptance criteria
- [x] `package.json` specifies `"next": "16.1.7"` (exact, no caret)
- [x] `eslint-config-next` updated to `"16.1.7"` (exact, no caret)
- [ ] `package-lock.json` regenerated — see "Lockfile note" below
- [ ] App builds via `npm run build` — needs CI with `@tari-project` npm-token
- [ ] Wrap/unwrap E2E in TU — needs maintainer-side test environment

## Lockfile note
Local regeneration of `package-lock.json` requires `npm install`, which pulls `@tari-project/wxtm-bridge-contracts@0.1.12` from a private registry. Without an `@tari-project` npm token, I can't regenerate the lockfile cleanly here. Two ways to close this:

1. CI on the PR (already authenticated to your private registry) regenerates and amends.
2. Add me as collaborator with read access to the private registry and I'll push the updated lockfile.

The mechanical pin in `package.json` is the substantive change; lockfile regen is a one-command follow-up.
