### PR TITLE
fix: pin Next.js and eslint-config-next to exact version 16.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
     "motion": "^12.26.2",
-    "next": "^16.1.1",
+    "next": "16.1.7",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.1",
@@ -40,7 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "@walletconnect/ethereum-provider": "^2.23.2",
     "eslint": "^9.39.2",
-    "eslint-config-next": "^16.1.1",
+    "eslint-config-next": "16.1.7",
     "eslint-plugin-i18next": "^6.1.3",
     "tailwindcss": "^4",
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
Fixes #103

Pins next and eslint-config-next from caret range ^16.1.1 to exact version 16.1.7 (latest patched release) to mitigate CVE risk.

### Changes
- next: ^16.1.1 -> 16.1.7
- eslint-config-next: ^16.1.1 -> 16.1.7

### Note
I do not have access to the private @tari-project npm packages needed to regenerate the lockfile and run the build locally. The package.json change is straightforward. A maintainer with registry access can regenerate the lockfile and verify the build. Happy to iterate if needed.