### PR TITLE
fix: pin Next.js to 16.1.7 to mitigate known CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
     "motion": "^12.26.2",
-    "next": "^16.1.1",
+    "next": "16.1.7",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.1",
@@ -40,7 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "@walletconnect/ethereum-provider": "^2.23.2",
     "eslint": "^9.39.2",
-    "eslint-config-next": "^16.1.1",
+    "eslint-config-next": "16.1.7",
     "eslint-plugin-i18next": "^6.1.3",
     "tailwindcss": "^4",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Pins Next.js and eslint-config-next to exact version 16.1.7 to prevent resolution to versions with known CVEs.

- `next` changed from `^16.1.1` to `16.1.7` (exact, no caret)
- `eslint-config-next` changed from `^16.1.1` to `16.1.7` (exact, no caret)

The caret allows npm to resolve any semver-compatible 16.x version, including versions with known CVEs. Pinning prevents this.

Fixes #103

---
Wallet: zp6