### PR TITLE
fix: Mitigate risks due to "next" known CVEs (Signed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
     "motion": "^12.26.2",
-    "next": "^16.1.1",
+    "next": "14.1.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.71.1",


### PR DESCRIPTION
This PR pins `next` to `14.1.1` to address CVEs. Re-opening to ensure the commit is properly signed from the start for the CI check. Closes #103