### PR TITLE
fix: enforce unwrap daily limit

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -116,8 +116,20 @@ export default function Home() {
       onNetworkChange()
       return
     }
-    const interval = setInterval(fetchDailyLimit, REFETCH_LIMIT_INTERVAL)
-    return () => clearInterval(interval)
+
+    let active = true
+
+    const updateDailyLimit = async () => {
+      const limit = await fetchDailyLimit()
+      if (active) setRemainingDailyLimit(limit)
+    }
+
+    void updateDailyLimit()
+    const interval = setInterval(updateDailyLimit, REFETCH_LIMIT_INTERVAL)
+    return () => {
+      active = false
+      clearInterval(interval)
+    }
   }, [fetchDailyLimit, fromNetwork.name])
 
   const handleSetOngoingModalOpen = (open: boolean) => {

--- a/hooks/use-bridge-to-tari.ts
+++ b/hooks/use-bridge-to-tari.ts
@@ -85,10 +85,11 @@ export const useBridgeToTari = (ethAddress: `0x${string}`, chain: DeployedChains
       const limitXtm = microXtmToXtm(limitMicro)
       const amountNum = parseFloat(amount)
 
-      if (limitXtm && amountNum > limitXtm) {
+      if (!Number.isFinite(limitXtm) || !Number.isFinite(amountNum) || amountNum > limitXtm) {
         setExceededDailyLimit(true)
-        new Error(`[ TAPPLET-BRIDGE ] Daily limit exceeded. Limit: ${limitXtm}, Amount: ${amountNum}`)
+        return false
       }
+      setExceededDailyLimit(false)
 
       const value = BigInt(ethers.utils.parseEther(amount).toString())
 


### PR DESCRIPTION
Fixes #137

## Summary

- fetch and store the remaining unwrap daily limit immediately when Ethereum -> Tari is selected
- refresh the stored value every 30 seconds so input validation receives the live limit
- stop the unwrap path before wallet signature / contract submission when the amount exceeds the remaining limit, including a zero remaining limit
- clear the stale warning state when a later preflight check passes

## Context

This restores the protection originally added in #96. During the later store cleanup, the polling hook's returned value stopped being written to `remainingDailyLimit`, and the final preflight guard was reduced to an inert `new Error(...)` expression with no control-flow exit.

## Verification

- `git diff --check origin/development...HEAD`
- code-path audit: the UI updater now calls `setRemainingDailyLimit(await fetchDailyLimit())` immediately and on the interval; the final guard returns before `parseEther`, typed-data signing, and `writeContract`

## Local validation constraint

`npm ci --ignore-scripts --no-audit --no-fund` could not complete in this environment because `@tari-project/wxtm-bridge-contracts@0.1.12` is served from GitHub Packages and the available token does not have the required package-read scope. Please run the normal build in the maintainer environment with package access.
