### PR TITLE
fix: load ethereum nodes from backend instead of broken default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.7",
         "@tanstack/react-query": "^5.90.17",
-        "@tari-project/wxtm-bridge-backend-api": "^0.1.68",
+        "@tari-project/wxtm-bridge-backend-api": "^0.1.69",
         "@tari-project/wxtm-bridge-contracts": "0.1.12",
         "ethers": "^5.8.0",
         "i18next": "^24.2.3",
@@ -3452,9 +3452,9 @@
       }
     },
     "node_modules/@tari-project/wxtm-bridge-backend-api": {
-      "version": "0.1.68",
-      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.68.tgz",
-      "integrity": "sha512-Pk8AACZOlNRsS1vIOJHLPGBtQD2UjCztPxEzPYE5BB82Xwf/n/DnG7XHkdTmxlFcUfzx/xWJlArS7IMKmZyh4A==",
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.69.tgz",
+      "integrity": "sha512-t4UB6LMCThq2YHMN6RpL7Q+5SVxKy6qkmAzK2xnrytfNDW3X8MsOIxdhlmSWjgZMmXPTNNxNwS3oVlJToFIj+A==",
       "license": "ISC"
     },
     "node_modules/@tari-project/wxtm-bridge-contracts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "wxtm-bridge-frontend",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wxtm-bridge-frontend",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.3.7",
         "@tanstack/react-query": "^5.90.17",
-        "@tari-project/wxtm-bridge-backend-api": "^0.1.63",
+        "@tari-project/wxtm-bridge-backend-api": "^0.1.68",
         "@tari-project/wxtm-bridge-contracts": "0.1.12",
         "ethers": "^5.8.0",
         "i18next": "^24.2.3",
@@ -1882,6 +1882,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
       "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "peerDependencies": {
@@ -3451,9 +3452,9 @@
       }
     },
     "node_modules/@tari-project/wxtm-bridge-backend-api": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.63.tgz",
-      "integrity": "sha512-fvOgYFfJTfb7UDcigMok1g60Y9+/6Lb9WQJF6EwMdCY/fZnrGj3p4XU+P7GcVKMWIUWNdQ6dsJyupXGZ6FwNFQ==",
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.68.tgz",
+      "integrity": "sha512-Pk8AACZOlNRsS1vIOJHLPGBtQD2UjCztPxEzPYE5BB82Xwf/n/DnG7XHkdTmxlFcUfzx/xWJlArS7IMKmZyh4A==",
       "license": "ISC"
     },
     "node_modules/@tari-project/wxtm-bridge-contracts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.7",
     "@tanstack/react-query": "^5.90.17",
-    "@tari-project/wxtm-bridge-backend-api": "^0.1.63",
+    "@tari-project/wxtm-bridge-backend-api": "^0.1.68",
     "@tari-project/wxtm-bridge-contracts": "0.1.12",
     "ethers": "^5.8.0",
     "i18next": "^24.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wxtm-bridge-frontend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.3.7",
     "@tanstack/react-query": "^5.90.17",
-    "@tari-project/wxtm-bridge-backend-api": "^0.1.68",
+    "@tari-project/wxtm-bridge-backend-api": "^0.1.69",
     "@tari-project/wxtm-bridge-contracts": "0.1.12",
     "ethers": "^5.8.0",
     "i18next": "^24.2.3",

--- a/store/app.ts
+++ b/store/app.ts
@@ -41,7 +41,9 @@ const fetchEthereumNodes = async (): Promise<PublicEthereumNodeRespDTO[]> => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      request.cancel()
+      if (typeof request.cancel === 'function') {
+        request.cancel()
+      }
       reject(new Error('Timed out fetching public ethereum nodes'))
     }, ETHEREUM_NODES_FETCH_TIMEOUT_MS)
   })

--- a/store/app.ts
+++ b/store/app.ts
@@ -49,7 +49,9 @@ const fetchEthereumNodes = async (): Promise<PublicEthereumNodeRespDTO[]> => {
   })
 
   try {
-    return await Promise.race([request, timeout])
+    const nodes = await Promise.race([request, timeout])
+    console.info('[ TAPPLET-BRIDGE ] loaded public ethereum nodes ', nodes)
+    return nodes
   } catch (error) {
     console.error('[ TAPPLET-BRIDGE ] failed to fetch public ethereum nodes ', error)
     return []

--- a/store/app.ts
+++ b/store/app.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand'
 import useTariSigner from './signer'
-import { OpenAPI } from '@tari-project/wxtm-bridge-backend-api'
+import { EthereumNodesService, OpenAPI, PublicEthereumNodeRespDTO } from '@tari-project/wxtm-bridge-backend-api'
 import i18next, { changeLanguage } from 'i18next'
 import { parseTheme, Theme } from '@/types/app'
 import { SupportedChain, supportedChains } from '@/utils/networksConfig'
+
+const ETHEREUM_NODES_FETCH_TIMEOUT_MS = 5000
 
 interface State {
   language: string
@@ -12,6 +14,7 @@ interface State {
   theme: Theme
   hideWalletBalance: boolean
   isMainNet: boolean
+  ethereumNodes: PublicEthereumNodeRespDTO[]
 }
 
 interface Actions {
@@ -27,6 +30,30 @@ const initialState: State = {
   theme: 'light',
   hideWalletBalance: false,
   isMainNet: true,
+  ethereumNodes: [],
+}
+
+// Fetch the backend-served public RPC nodes. Times out and falls back to an
+// empty list so a slow/unreachable backend never blocks app startup; viem's
+// default transports are used for any chain without configured nodes.
+const fetchEthereumNodes = async (): Promise<PublicEthereumNodeRespDTO[]> => {
+  const request = EthereumNodesService.getPublicNodes()
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      request.cancel()
+      reject(new Error('Timed out fetching public ethereum nodes'))
+    }, ETHEREUM_NODES_FETCH_TIMEOUT_MS)
+  })
+
+  try {
+    return await Promise.race([request, timeout])
+  } catch (error) {
+    console.error('[ TAPPLET-BRIDGE ] failed to fetch public ethereum nodes ', error)
+    return []
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 const useAppStore = create<AppStoreState>()((_, get) => ({
@@ -56,10 +83,14 @@ export const setAppConfig = async () => {
 
     const walletConnectProjectId = envs?.[0] ?? ''
     const bridgeAPI = envs?.[1] ?? ''
-    useAppStore.setState({ walletConnectProjectId, bridgeAPI, isMainNet })
 
-    // set OpenAPI configuration
+    // set OpenAPI configuration before fetching the public ethereum nodes
     OpenAPI.BASE = bridgeAPI
+
+    // Fetch nodes before exposing walletConnectProjectId: setting it triggers the
+    // wagmi config build in Providers, which reads ethereumNodes from this store.
+    const ethereumNodes = await fetchEthereumNodes()
+    useAppStore.setState({ walletConnectProjectId, bridgeAPI, isMainNet, ethereumNodes })
 
     const appLanguage = await signer.getAppLanguage()
     if (appLanguage) await setLanguage(appLanguage)

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,16 +1,27 @@
 import useAppStore from '@/store/app'
-import { http, createConfig, createStorage, cookieStorage } from 'wagmi'
+import { createConfig, createStorage, cookieStorage, fallback, http } from 'wagmi'
 import { mainnet, baseSepolia, sepolia } from 'wagmi/chains'
 import { walletConnect } from 'wagmi/connectors'
 
 export function getConfig(id?: string) {
-  const projectId = id || useAppStore.getState().walletConnectProjectId
+  const { walletConnectProjectId, ethereumNodes } = useAppStore.getState()
+  const projectId = id || walletConnectProjectId
+
+  const urlsByChain = new Map(ethereumNodes.map((node) => [node.chainId, node.urls]))
+
+  // Prefer the backend-served public RPC nodes; fall back to viem's defaults
+  // when the backend has no nodes for a chain (or the list could not be fetched).
+  const transportFor = (chainId: number) => {
+    const urls = urlsByChain.get(chainId)
+    return urls?.length ? fallback(urls.map((url) => http(url))) : http()
+  }
+
   return createConfig({
     chains: [mainnet, baseSepolia, sepolia],
     transports: {
-      [mainnet.id]: http(),
-      [sepolia.id]: http(),
-      [baseSepolia.id]: http(),
+      [mainnet.id]: transportFor(mainnet.id),
+      [sepolia.id]: transportFor(sepolia.id),
+      [baseSepolia.id]: transportFor(baseSepolia.id),
     },
     connectors: [
       walletConnect({

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -7,12 +7,12 @@ export function getConfig(id?: string) {
   const { walletConnectProjectId, ethereumNodes } = useAppStore.getState()
   const projectId = id || walletConnectProjectId
 
-  const urlsByChain = new Map(ethereumNodes.map((node) => [node.chainId, node.urls]))
+  const urlsByChain = new Map(ethereumNodes.map((node) => [Number(node.chainId), node.urls]))
 
   // Prefer the backend-served public RPC nodes; fall back to viem's defaults
   // when the backend has no nodes for a chain (or the list could not be fetched).
   const transportFor = (chainId: number) => {
-    const urls = urlsByChain.get(chainId)
+    const urls = urlsByChain.get(chainId)?.filter((url) => url.trim() !== '')
     return urls?.length ? fallback(urls.map((url) => http(url))) : http()
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
   dependencies:
     "@tanstack/query-core" "5.90.17"
 
-"@tari-project/wxtm-bridge-backend-api@^0.1.68":
-  version "0.1.68"
-  resolved "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.68.tgz"
-  integrity sha512-Pk8AACZOlNRsS1vIOJHLPGBtQD2UjCztPxEzPYE5BB82Xwf/n/DnG7XHkdTmxlFcUfzx/xWJlArS7IMKmZyh4A==
+"@tari-project/wxtm-bridge-backend-api@^0.1.69":
+  version "0.1.69"
+  resolved "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.69.tgz"
+  integrity sha512-t4UB6LMCThq2YHMN6RpL7Q+5SVxKy6qkmAzK2xnrytfNDW3X8MsOIxdhlmSWjgZMmXPTNNxNwS3oVlJToFIj+A==
 
 "@tari-project/wxtm-bridge-contracts@0.1.12":
   version "0.1.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
   dependencies:
     "@tanstack/query-core" "5.90.17"
 
-"@tari-project/wxtm-bridge-backend-api@^0.1.63":
-  version "0.1.63"
-  resolved "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.63.tgz"
-  integrity sha512-fvOgYFfJTfb7UDcigMok1g60Y9+/6Lb9WQJF6EwMdCY/fZnrGj3p4XU+P7GcVKMWIUWNdQ6dsJyupXGZ6FwNFQ==
+"@tari-project/wxtm-bridge-backend-api@^0.1.68":
+  version "0.1.68"
+  resolved "https://registry.npmjs.org/@tari-project/wxtm-bridge-backend-api/-/wxtm-bridge-backend-api-0.1.68.tgz"
+  integrity sha512-Pk8AACZOlNRsS1vIOJHLPGBtQD2UjCztPxEzPYE5BB82Xwf/n/DnG7XHkdTmxlFcUfzx/xWJlArS7IMKmZyh4A==
 
 "@tari-project/wxtm-bridge-contracts@0.1.12":
   version "0.1.12"


### PR DESCRIPTION
Description
---

The app now gets its list of Ethereum connection nodes from our backend instead of relying on a fixed default one. If a node ever stops working, we can swap it from the admin panel — no app release needed.

Closes #102 

Motivation and Context
---

The default public node the app was using has been down for quite some while, which could break wallet connections. Serving the list from the backend lets us keep it up to date instantly. If the backend can't be reached, the app safely falls back to the previous default behaviour and won't hang on startup.


How Has This Been Tested?
---

- Verified the app builds and passes type and lint checks.
- Confirmed the app starts normally whether or not nodes are returned (falls back gracefully).


What process can a PR reviewer use to test or verify this change?
---

1. Add a working node in the admin panel.
2. Open the app and check (browser Network tab) that requests go to the configured node, not the old `eth.merkle.io`.
3. With no nodes configured, confirm the app still loads normally.


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
