### PR TITLE
fix(#103): pin Next.js to exact 16.1.7 to mitigate CVE risk

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,47 +2,27 @@
   "name": "wxtm-bridge-frontend",
   "version": "0.4.2",
   "private": true,
-  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build --debug",
     "start": "next start",
-    "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
-    "translate": "node ./scripts/translator.js"
+    "lint": "next lint"
   },
   "dependencies": {
-    "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.1",
-    "@mui/material": "^7.3.7",
-    "@tanstack/react-query": "^5.90.17",
-    "@tari-project/wxtm-bridge-backend-api": "^0.1.69",
-    "@tari-project/wxtm-bridge-contracts": "0.1.12",
-    "ethers": "^5.8.0",
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
-    "motion": "^12.26.2",
-    "next": "^16.1.1",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-hook-form": "^7.71.1",
-    "react-i18next": "^15.7.4",
-    "react-icons": "^5.5.0",
-    "styled-components": "^6.3.6",
-    "viem": "^2.44.2",
-    "wagmi": "^3.3.2",
-    "zustand": "^5.0.10"
+    "next": "16.1.7",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-i18next": "^15.7.4"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.18",
-    "@types/node": "^25.0.8",
-    "@types/react": "^19.2.8",
-    "@types/react-dom": "^19.2.3",
-    "@walletconnect/ethereum-provider": "^2.23.2",
-    "eslint": "^9.39.2",
-    "eslint-config-next": "^16.1.1",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.1.7",
     "eslint-plugin-i18next": "^6.1.3",
-    "tailwindcss": "^4",
-    "typescript": "^5.9.3"
+    "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,27 +2,47 @@
   "name": "wxtm-bridge-frontend",
   "version": "0.4.2",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build --debug",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "translate": "node ./scripts/translator.js"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^7.3.7",
+    "@tanstack/react-query": "^5.90.17",
+    "@tari-project/wxtm-bridge-backend-api": "^0.1.69",
+    "@tari-project/wxtm-bridge-contracts": "0.1.12",
+    "ethers": "^5.8.0",
     "i18next": "^24.2.3",
     "i18next-http-backend": "^3.0.2",
+    "motion": "^12.26.2",
     "next": "16.1.7",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-i18next": "^15.7.4"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-hook-form": "^7.71.1",
+    "react-i18next": "^15.7.4",
+    "react-icons": "^5.5.0",
+    "styled-components": "^6.3.6",
+    "viem": "^2.44.2",
+    "wagmi": "^3.3.2",
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
+    "@tailwindcss/postcss": "^4.1.18",
+    "@types/node": "^25.0.8",
+    "@types/react": "^19.2.8",
+    "@types/react-dom": "^19.2.3",
+    "@walletconnect/ethereum-provider": "^2.23.2",
+    "eslint": "^9.39.2",
     "eslint-config-next": "16.1.7",
     "eslint-plugin-i18next": "^6.1.3",
-    "typescript": "^5"
+    "tailwindcss": "^4",
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Fixes #103

Pins  to  (exact, no caret) and updates  to match. Removes the caret from both to prevent npm from resolving to any semver-compatible version including those with known CVEs.

## Changes
- :  pinned to  (was )
- :  pinned to  (was )

## Acceptance Criteria
- [x]  is exactly  with no caret
- [x]  matches